### PR TITLE
feat: add interactive power menu with rofi integration

### DIFF
--- a/config.py
+++ b/config.py
@@ -128,6 +128,12 @@ keys = [
         lazy.spawn("cinnamon-screensaver-command --lock"),
         desc="Lock screen",
     ),
+    Key(
+        [mod, "shift"],
+        "e",
+        lazy.spawn(os.path.expanduser("~/.config/qtile/install/rofi/powermenu.sh")),
+        desc="Power menu",
+    ),
 ]
 
 groups = [Group(str(i)) for i in range(1, 10)]

--- a/install/rofi/powermenu.sh
+++ b/install/rofi/powermenu.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Interactive power menu using rofi
+
+# Options
+shutdown="⏻ Shutdown"
+reboot="⟲ Reboot"
+logout="⇠ Logout"
+lock="🔒 Lock"
+suspend="⏸ Suspend"
+cancel="✘ Cancel"
+
+# Show options
+chosen=$(echo -e "$shutdown\n$reboot\n$logout\n$lock\n$suspend\n$cancel" | rofi -dmenu -i -p "Power Menu" -theme-str 'window {width: 300px;}' -theme-str 'listview {lines: 6;}')
+
+# Execute based on choice
+case $chosen in
+    "$shutdown")
+        systemctl poweroff
+        ;;
+    "$reboot")
+        systemctl reboot
+        ;;
+    "$logout")
+        qtile cmd-obj -o cmd -f shutdown
+        ;;
+    "$lock")
+        cinnamon-screensaver-command --lock
+        ;;
+    "$suspend")
+        systemctl suspend
+        ;;
+    "$cancel")
+        exit 0
+        ;;
+    *)
+        exit 0
+        ;;
+esac


### PR DESCRIPTION
## Summary
- Added rofi-based interactive power menu accessible via Super+Shift+E
- Provides shutdown, reboot, logout, lock, suspend, and cancel options
- Uses standard systemctl commands (no sudo required)
- Consistent with existing rofi integration pattern

## Test plan
- [ ] Test keybinding Super+Shift+E opens power menu
- [ ] Verify all power menu options work correctly
- [ ] Confirm no sudo password prompts appear

🤖 Generated with [Claude Code](https://claude.ai/code)