### PR TITLE
fix: correct ansible handler definition and disable cowsay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -244,3 +244,5 @@ __marimo__/
 
 # Alacritty themes (cloned from external repository)
 install/alacritty/themes/
+
+tmp/

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+nocows = True

--- a/ansible/roles/locale-setup/handlers/main.yml
+++ b/ansible/roles/locale-setup/handlers/main.yml
@@ -1,4 +1,7 @@
 ---
 - name: update locale
   command: /usr/sbin/locale-gen
-  notify: reload systemd
+
+- name: reload systemd
+  systemd:
+    daemon_reload: yes


### PR DESCRIPTION
## Summary
- Fix malformed handler in locale-setup role that was causing "handler not found" error
- Add ansible.cfg to disable cowsay output for consistent experience across machines

## Test plan
- [ ] Run ansible playbook on laptop without handler errors
- [ ] Verify cowsay is disabled during playbook execution

🤖 Generated with [Claude Code](https://claude.ai/code)